### PR TITLE
feat(i18n): 添加所属部门国际化文本

### DIFF
--- a/locales/lang/en.json
+++ b/locales/lang/en.json
@@ -778,5 +778,6 @@
   "positions.index.223804-1": "Superior positions",
   "positions.index.223804-2": "Please select a superior position",
   "positions.index.223804-3": "Please add position information first",
-  "positions.index.223804-4": "Please enter the position name"
+  "positions.index.223804-4": "Please enter the position name",
+  "Instance.index.133466-16": "Belonging department"
 }

--- a/locales/lang/zh.json
+++ b/locales/lang/zh.json
@@ -778,5 +778,6 @@
   "positions.index.223804-1": "上级职位",
   "positions.index.223804-2": "请选择上级职位",
   "positions.index.223804-3": "请先新增职位信息",
-  "positions.index.223804-4": "请输入职位名称"
+  "positions.index.223804-4": "请输入职位名称",
+  "Instance.index.133466-16": "所属部门"
 }


### PR DESCRIPTION
新增 Instance.index.133466-16 国际化键值对，用于显示"所属部门"文本，
同时修正了 positions.index.223804-4 条目的格式，在末尾添加逗号以符合
JSON 格式规范。