### PR TITLE
feat: 访问日志支持按响应码查询

### DIFF
--- a/locales/lang/en.json
+++ b/locales/lang/en.json
@@ -878,6 +878,7 @@
   "Access.index.480752-13": "Request User",
   "Access.index.480752-14": "Action",
   "Access.index.480752-15": "View",
+  "Access.index.responseStatus": "Status Code",
   "device-manager-ui.index.106686-0": "Details",
   "router.extraMenu.260658-4": "Position Details",
   "components.AddDeviceOrProductDialog.314014-0": "Asset Assignment",

--- a/locales/lang/zh.json
+++ b/locales/lang/zh.json
@@ -878,6 +878,7 @@
   "Access.index.480752-13": "请求用户",
   "Access.index.480752-14": "操作",
   "Access.index.480752-15": "查看",
+  "Access.index.responseStatus": "状态码",
   "device-manager-ui.index.106686-0": "详情",
   "router.extraMenu.260658-4": "职位详情",
   "components.AddDeviceOrProductDialog.314014-0": "资产分配",

--- a/views/system/Log/Access/index.vue
+++ b/views/system/Log/Access/index.vue
@@ -27,6 +27,11 @@
                         {{ slotProps.responseTime - slotProps.requestTime }} ms
                     </a-tag>
                     </template>
+                    <template #responseStatus="slotProps">
+                    <a-tag :color="getResponseStatusColor(slotProps.responseStatus)">
+                        {{ slotProps.responseStatus ?? '-' }}
+                    </a-tag>
+                    </template>
                     <template #username="slotProps">
 
                     <!-- <j-tag color="geekblue"> -->
@@ -95,6 +100,9 @@
                             'ms'
                         }}
                     </a-descriptions-item>
+                    <a-descriptions-item :label="$t('Access.index.responseStatus')">
+                        {{ descriptionsData?.responseStatus ?? '-' }}
+                    </a-descriptions-item>
                     <a-descriptions-item :label="$t('Access.index.480752-7')" :span="2">
                         {{ descriptionsData?.httpHeaders }}
                     </a-descriptions-item>
@@ -122,6 +130,10 @@ import { useI18n } from 'vue-i18n';
 const { t: $t } = useI18n();
 const tableRef = ref<Record<string, any>>({});
 const params = ref<Record<string, any>>({});
+const responseStatusOptions = [200, 400, 401, 403, 404, 500, 502, 503].map((code) => ({
+    label: String(code),
+    value: code,
+}));
 
 const columns = [
     {
@@ -187,6 +199,17 @@ const columns = [
         width: 100,
     },
     {
+        title: $t('Access.index.responseStatus'),
+        dataIndex: 'responseStatus',
+        key: 'responseStatus',
+        search: {
+            type: 'select',
+            options: responseStatusOptions,
+        },
+        scopedSlots: true,
+        width: 120,
+    },
+    {
         title: $t('Access.index.480752-5'),
         dataIndex: 'requestTime',
         key: 'requestTime',
@@ -228,6 +251,7 @@ const descriptionsData = ref<any>({
     action: '',
     target: '',
     method: '',
+    responseStatus: 0,
     ip: '',
     requestTime: 0,
     responseTime: 0,
@@ -259,6 +283,22 @@ const getActions = (data: Partial<Record<string, any>>): ActionsType[] => {
             },
         },
     ];
+};
+
+const getResponseStatusColor = (status?: number) => {
+    if (!status) {
+        return 'default';
+    }
+    if (status >= 500) {
+        return 'error';
+    }
+    if (status >= 400) {
+        return 'warning';
+    }
+    if (status >= 300) {
+        return 'processing';
+    }
+    return 'success';
 };
 
 const column = {

--- a/views/system/Log/typings.d.ts
+++ b/views/system/Log/typings.d.ts
@@ -1,4 +1,6 @@
-import type { PopconfirmProps } from "ant-design-vue/es/popconfirm";
+import type { CSSProperties } from 'vue';
+import type { TooltipProps } from 'ant-design-vue';
+import type { PopconfirmProps } from 'ant-design-vue/es/popconfirm';
 export type AccessLogItem = {
   id: string;
   context: any;
@@ -6,6 +8,7 @@ export type AccessLogItem = {
   exception: string;
   httpHeaders: any;
   httpMethod: string;
+  responseStatus: number;
   ip: string;
   method: string;
   parameters: any;


### PR DESCRIPTION
## 变更说明
- 访问日志列表增加响应码列和筛选项
- 访问日志详情补充响应码展示
- 补充响应码字段类型与中英文文案
- 使用颜色标签区分不同响应码区间

## 验证
- 未单独跑模块构建；当前 `runtime-ui` 根级 `pnpm exec vue-tsc --noEmit --pretty false` 会因现有 tsconfig 中的 `suppressImplicitAnyIndexErrors` 配置报错，属于仓库现状，不是这次改动引入