### PR TITLE
fix（用户管理）：锁定项目所有者角色

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 `authentication-manager-ui` provides account, organization, permission, system application, and related management pages for the operations UI.
 
+## Project Owner Role Editing Guard
+
+The system user edit dialog keeps profile fields editable for project owners while disabling the role selector when the stable runtime user type is `projectOwner`. The guard accepts the user-list `typeId` and the detail response enum object so list and detail response shapes behave consistently. It reuses the existing `FormItemRole` disabled contract, which also hides the add-role action and prevents tag removal. Scope is limited to `views/system/User/components/EditUserDialog.vue`; user APIs, backend authorization, other user types, organizations, positions, and password operations remain unchanged. The module production build (`pnpm -F jetlinks-web-core build -- --module-name authentication-manager-ui`) and `git diff --check` pass. The touched Vue file remains over the preferred 300-line limit because this is a narrow fix in an existing 491-line component; no structural refactor is included.
+
 ## System Two-column Layout Unification
 
 The page-level left/right shells under `views/system/` now use the shared `EqualHeightColumns` component. Every matching page uses a `18.75rem` left track and `1fr` right track, with no outer padding, column divider, or hand-written flex/absolute/calc width compensation.

--- a/views/system/User/components/EditUserDialog.vue
+++ b/views/system/User/components/EditUserDialog.vue
@@ -79,7 +79,7 @@
 <!--                      :rules="[-->
 <!--                      { required: form.data.username !== 'admin', message: $t('components.EditUserDialog.939453-13') },-->
 <!--                      ]"-->
-                      <form-item-role :extraData="detail.roleList" :extraProps="{multiple: true}" :disabledData="disabledData.roles" v-model:value="form.data.roleIdList" :disabled="form.data.username === 'admin'" />
+                      <form-item-role :extraData="detail.roleList" :extraProps="{multiple: true}" :disabledData="disabledData.roles" v-model:value="form.data.roleIdList" :disabled="isRoleReadonly" />
                       <div v-if="isNoCommunity" class="tip"><AIcon style="margin-right: 0.25rem" type="ExclamationCircleOutlined" />{{$t('components.EditUserDialog.939453-33')}}</div>
                     </a-form-item>
                 </a-col>
@@ -259,6 +259,18 @@ const onChange = (value: string[]) => {
 
 const formRef = ref<FormInstance>();
 const _roleDetail = ref([] as any[]);
+const PROJECT_OWNER_USER_TYPE = 'projectOwner';
+
+const resolveUserTypeId = (value: unknown): string => {
+    if (typeof value === 'string') return value;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+        const record = value as Record<string, unknown>;
+        const typeId = record.id ?? record.value;
+        return typeof typeId === 'string' ? typeId : '';
+    }
+    return '';
+};
+
 const form = reactive({
     data: {} as formType,
     rules: {
@@ -362,6 +374,16 @@ const form = reactive({
     },
     IsShow: (...typeList: modalType[]) => typeList.includes(props.type),
 });
+
+// 列表使用 typeId，详情可能返回 type 枚举对象；两种形态都必须锁定项目所有者的角色。
+const isProjectOwner = computed(() => [
+    form.data.typeId,
+    props.data?.typeId,
+    resolveUserTypeId(form.data.type),
+    resolveUserTypeId(props.data?.type),
+].some(typeId => typeId === PROJECT_OWNER_USER_TYPE));
+const isRoleReadonly = computed(() => form.data.username === 'admin' || isProjectOwner.value);
+
 const checkCh = async(_rule:Rule,value:string) => {
                 if (/[\u4e00-\u9fa5]/.test(value)) return Promise.reject($t('components.EditUserDialog.939453-30'));
                 else return Promise.resolve('')
@@ -425,6 +447,8 @@ type axiosFunType = (data: any) => Promise<AxiosResponseRewrite<unknown>>;
 type modalType = '' | 'add' | 'edit' | 'reset';
 type formType = {
     id?: string;
+    typeId?: string;
+    type?: string | { id?: string; value?: string };
     name: string;
     username: string;
     password: string;


### PR DESCRIPTION
## 变更\n- 编辑项目所有者时禁用角色选择器\n- 兼容列表 typeId 与详情 type 枚举对象两种返回形态\n- 保留其他资料字段编辑能力\n\n## 验证\n- 模块生产构建通过\n- git diff --check 通过