### PR TITLE
refactor(menu): 恢复通用菜单同步流程

### DIFF
--- a/views/system/Menu/Setting/index.vue
+++ b/views/system/Menu/Setting/index.vue
@@ -281,11 +281,7 @@ const synchronization = async () => {
 //双重遍历系统菜单和初始化菜单做菜单和按钮权限和接口权限的合并处理
 const synchronizationMenu = (menu: any, baseMenu: any) => {
   const baseByCode = new Map(baseMenu.map((item: any) => [item.code, item]));
-  // 只清理本模块拥有且已从 baseMenu 移除的节点；其他模块/人工菜单必须原样保留。
-  const isEnergyStationMenu = (item: any) =>
-    item.owner === 'energy-station' || item.options?.appName === 'energy-station';
   const newMenu = menu
-    .filter((item: any) => !isEnergyStationMenu(item) || baseByCode.has(item.code))
     .map((i: any) => {
       const item = baseByCode.get(i.code) || baseMenu.find((candidate: any) => candidate.id === i.id);
       if (item) {

--- a/views/system/Menu/Setting/index.vue
+++ b/views/system/Menu/Setting/index.vue
@@ -280,18 +280,23 @@ const synchronization = async () => {
 
 //双重遍历系统菜单和初始化菜单做菜单和按钮权限和接口权限的合并处理
 const synchronizationMenu = (menu: any, baseMenu: any) => {
-  const newMenu = menu.map((i: any) => {
-    baseMenu.find((item: any) => {
-      if (i.id === item.id) {
+  const baseByCode = new Map(baseMenu.map((item: any) => [item.code, item]));
+  // 只清理本模块拥有且已从 baseMenu 移除的节点；其他模块/人工菜单必须原样保留。
+  const isEnergyStationMenu = (item: any) =>
+    item.owner === 'energy-station' || item.options?.appName === 'energy-station';
+  const newMenu = menu
+    .filter((item: any) => !isEnergyStationMenu(item) || baseByCode.has(item.code))
+    .map((i: any) => {
+      const item = baseByCode.get(i.code) || baseMenu.find((candidate: any) => candidate.id === i.id);
+      if (item) {
         i.buttons = unionBy(i.buttons, item.buttons, "id");
         i.permissions = unionBy(i.permissions, item.permissions, "permission");
-        if (item.children && i.children) {
-          i.children = synchronizationMenu(i.children, item.children);
+        if (item.children || i.children) {
+          i.children = synchronizationMenu(i.children || [], item.children || []);
         }
       }
+      return i;
     });
-    return i;
-  });
   return unionBy(newMenu, baseMenu, "code");
 };
 onMounted(() => {


### PR DESCRIPTION
## 目的

- 让认证模块的菜单设置回归平台通用菜单管理流程，不在通用组件中写能源场站等业务场景特调。

## 核心变动

- 提交 `a1a78aa`：移除 `synchronizationMenu` 对 `energy-station` owner/appName 的特殊判断。
- 同步只按菜单 code 合并当前 `baseMenu`，补充默认菜单、按钮和权限，不自动删除任何业务模块或人工维护的存量菜单。
- 新库由初始化流程写入默认菜单；存量菜单由超管在菜单管理页显式下线或删除。

## 测试结果

- `pnpm --dir ui --filter jetlinks-web-core build -- --module-name authentication-manager-ui` 通过，8034 个模块转换完成。
- 仅保留既有构建告警（CSS 注释、大 chunk 和 Vite 输出选项提示），无构建失败。